### PR TITLE
feat(frontend): display active concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ docker-compose up
 | `OLLAMA_HOST`        | Ollama Host (default: http://localhost:11434)                | No | Required only if you want to use external Ollama server                                                  |
 | `PORT`               | Port for the API server (default: 8001)                      | No | If you host API and frontend on the same machine, make sure change port of `SERVER_BASE_URL` accordingly |
 | `SERVER_BASE_URL`    | Base URL for the API server (default: http://localhost:8001) | No |
+| `NEXT_PUBLIC_MAX_CONCURRENT` | Maximum concurrent page generation (default: 1) | No | Controls client-side concurrency |
 | `DEEPWIKI_AUTH_MODE` | Set to `true` or `1` to enable authorization mode. | No | Defaults to `false`. If enabled, `DEEPWIKI_AUTH_CODE` is required. |
 | `DEEPWIKI_AUTH_CODE` | The secret code required for wiki generation when `DEEPWIKI_AUTH_MODE` is enabled. | No | Only used if `DEEPWIKI_AUTH_MODE` is `true` or `1`. |
 

--- a/src/app/[owner]/[repo]/page.tsx
+++ b/src/app/[owner]/[repo]/page.tsx
@@ -216,6 +216,17 @@ export default function RepoWikiPage() {
   const [effectiveRepoInfo, setEffectiveRepoInfo] = useState(repoInfo); // Track effective repo info with cached data
   const [embeddingError, setEmbeddingError] = useState(false);
 
+  // Track current active generation count and limit
+  const [currentConcurrency, setCurrentConcurrency] = useState(0);
+  const parsedConcurrency = parseInt(
+    process.env.NEXT_PUBLIC_MAX_CONCURRENT || '1',
+    10,
+  );
+  const initialMaxConcurrency = Number.isNaN(parsedConcurrency)
+    ? 1
+    : parsedConcurrency;
+  const [maxConcurrency, setMaxConcurrency] = useState(initialMaxConcurrency);
+
   // Model selection state variables
   const [selectedProviderState, setSelectedProviderState] = useState(providerParam);
   const [selectedModelState, setSelectedModelState] = useState(modelParam);
@@ -1002,8 +1013,11 @@ IMPORTANT:
 
         console.log(`Starting generation for ${pages.length} pages with controlled concurrency`);
 
-        // Maximum concurrent requests
-        const MAX_CONCURRENT = 1;
+        // Log concurrency limit for verification
+        console.log(
+          `MAX_CONCURRENT set to ${maxConcurrency} ` +
+            `(env: ${process.env.NEXT_PUBLIC_MAX_CONCURRENT ?? 'undefined'})`,
+        );
 
         // Create a queue of pages
         const queue = [...pages];
@@ -1012,10 +1026,11 @@ IMPORTANT:
         // Function to process next items in queue
         const processQueue = () => {
           // Process as many items as we can up to our concurrency limit
-          while (queue.length > 0 && activeRequests < MAX_CONCURRENT) {
+          while (queue.length > 0 && activeRequests < maxConcurrency) {
             const page = queue.shift();
             if (page) {
               activeRequests++;
+              setCurrentConcurrency(activeRequests);
               console.log(`Starting page ${page.title} (${activeRequests} active, ${queue.length} remaining)`);
 
               // Start generating content for this page
@@ -1023,16 +1038,18 @@ IMPORTANT:
                 .finally(() => {
                   // When done (success or error), decrement active count and process more
                   activeRequests--;
+                  setCurrentConcurrency(activeRequests);
                   console.log(`Finished page ${page.title} (${activeRequests} active, ${queue.length} remaining)`);
 
                   // Check if all work is done (queue empty and no active requests)
                   if (queue.length === 0 && activeRequests === 0) {
                     console.log("All page generation tasks completed.");
+                    setCurrentConcurrency(0);
                     setIsLoading(false);
                     setLoadingMessage(undefined);
                   } else {
                     // Only process more if there are items remaining and we're under capacity
-                    if (queue.length > 0 && activeRequests < MAX_CONCURRENT) {
+                    if (queue.length > 0 && activeRequests < maxConcurrency) {
                       processQueue();
                     }
                   }
@@ -1045,10 +1062,12 @@ IMPORTANT:
             // This handles the case where the queue might finish before the finally blocks fully update activeRequests
             // or if the initial queue was processed very quickly
             console.log("Queue empty and no active requests after loop, ensuring loading is false.");
+            setCurrentConcurrency(0);
             setIsLoading(false);
             setLoadingMessage(undefined);
           } else if (pages.length === 0) {
             // Handle case where there were no pages to begin with
+            setCurrentConcurrency(0);
             setIsLoading(false);
             setLoadingMessage(undefined);
           }
@@ -1838,6 +1857,9 @@ IMPORTANT:
                             .replace('{completed}', (wikiStructure.pages.length - pagesInProgress.size).toString())
                             .replace('{total}', wikiStructure.pages.length.toString())
                         : `${wikiStructure.pages.length - pagesInProgress.size} of ${wikiStructure.pages.length} pages completed`}
+                </p>
+                <p className="text-xs text-[var(--muted)] text-center mt-1">
+                  {`Active generation: ${currentConcurrency} / ${maxConcurrency}`}
                 </p>
 
                 {/* Show list of in-progress pages */}

--- a/src/app/api/auth/status/route.ts
+++ b/src/app/api/auth/status/route.ts
@@ -1,8 +1,8 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
 const TARGET_SERVER_BASE_URL = process.env.SERVER_BASE_URL || 'http://localhost:8001';
 
-export async function GET(request: NextRequest) {
+export async function GET() {
   try {
     // Forward the request to the backend API
     const response = await fetch(`${TARGET_SERVER_BASE_URL}/auth/status`, {


### PR DESCRIPTION
## Summary
- show active concurrent generations in the wiki UI
- store concurrency limit in state for easier reference
- fix lint error in auth status route
- use env concurrency on mount

## Testing
- `npm run lint`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685b1ebf9bfc832ea8bb63378d559836